### PR TITLE
Fix/chromedriver version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+node_modules.bak
 .idea
 build
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
     "chai": "^3.5.0",
+    "chromedriver": "^2.27.3",
     "css-loader": "^0.23.1",
     "del": "^2.0.2",
     "enzyme": "^2.2.0",

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -22,6 +22,7 @@ var specs = [
 var config = {
   framework: 'jasmine2',
   specs: specs,
+  chromeDriver: './node_modules/chromedriver/lib/chromedriver/chromedriver',
   onPrepare: function () {
     browser.ignoreSynchronization = true;
     /**
@@ -54,7 +55,7 @@ if (process.env.TRAVIS) {
     'name': 'react-es6-redux E2E node v' + process.env.TRAVIS_NODE_VERSION,
     'browserName': 'chrome',
     'seleniumVersion': '2.48.2',
-    'chromedriverVersion': '2.20',
+    'chromedriverVersion': '2.28',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER
   };

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -55,7 +55,7 @@ if (process.env.TRAVIS) {
     'name': 'react-es6-redux E2E node v' + process.env.TRAVIS_NODE_VERSION,
     'browserName': 'chrome',
     'seleniumVersion': '2.48.2',
-    'chromedriverVersion': '2.28',
+    'chromedriverVersion': '2.20',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER
   };


### PR DESCRIPTION
fixes #18

Since chrome 56, `webdriver update` won't work properly. Found a fix by using [chromedriver](https://www.npmjs.com/package/chromedriver) npm package and referencing it in `protractor.config.js` file as  `chromeDriver: './node_modules/chromedriver/lib/chromedriver/chromedriver',`.

See : https://github.com/angular/protractor/issues/3639#issuecomment-253701472

Anyone who'd like to help to upgrade protractor from v3 to v5 is welcome.